### PR TITLE
DEV-31835 Allow override of Maven URL from where artifacts are fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ export ZIPKIN_UI_ENVIRONMENT="qa"
 General attributes:
 
 * `node['zipkin']['version']`: Version to install.
+* `node['zipkin']['maven_base_url']`: Maven repository to fetch artifacts from.
+Defaults to `https://repo1.maven.org/maven2`
 * `node['zipkin']['install_dir']`: Where to install the application. Defaults
 to `/opt/zipkin`.
 * `node['zipkin']['manage_user']`: Should we create the user and group?

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,8 @@
 
 # Base configuration
 default['zipkin']['install_dir'] = '/opt/zipkin'
-default['zipkin']['version'] = '2.0.0'
+default['zipkin']['version'] = '2.3.0'
+default['zipkin']['maven_base_url'] = 'https://repo1.maven.org/maven2'
 default['zipkin']['user'] = 'zipkin'
 default['zipkin']['group'] = 'zipkin'
 default['zipkin']['uid'] = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -8,6 +8,26 @@ def zipkin_jar_file
   'zipkin.jar'
 end
 
+def zipkin_maven_group
+  'io.zipkin.java'
+end
+
+def zipkin_maven_artifact
+  'zipkin-server'
+end
+
+def zipkin_maven_artifact_file
+  [zipkin_maven_artifact, node['zipkin']['version'], 'exec.jar'].join('-')
+end
+
+def zipkin_kafka_maven_artifact
+  'zipkin-autoconfigure-collector-kafka10'
+end
+
+def zipkin_kafka_maven_artifact_file
+  [zipkin_kafka_maven_artifact, node['zipkin']['version'], 'module.jar'].join('-')
+end
+
 def zipkin_kafka_jar_file
   'zipkin-collector-kafka.jar'
 end
@@ -18,6 +38,24 @@ end
 
 def zipkin_kafka_jar_path
   ::File.join(zipkin_version_dir, zipkin_kafka_jar_file)
+end
+
+def zipkin_jar_remote_url
+  zipkin_remote_url(zipkin_maven_artifact, zipkin_maven_artifact_file)
+end
+
+def zipkin_kafka_jar_remote_url
+  zipkin_remote_url(zipkin_kafka_maven_artifact, zipkin_kafka_maven_artifact_file)
+end
+
+def zipkin_remote_url(artifact, artifact_file)
+  ::File.join(
+    node['zipkin']['maven_base_url'],
+    zipkin_maven_group.tr('.', '/'),
+    artifact,
+    node['zipkin']['version'],
+    artifact_file
+  )
 end
 
 def zipkin_version_dir

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rich@curalate.com '
 license          'MIT'
 description      'Installs and configures Zipkin, a distributed tracing system.'
 long_description 'Installs and configures Zipkin, a distributed tracing system.'
-version          '0.3.0'
+version          '0.4.0'
 source_url       'https://github.com/curalate/chef-zipkin' if respond_to?(:source_url)
 issues_url       'https://github.com/curalate/chef-zipkin/issues' if respond_to?(:issues_url)
 

--- a/recipes/_install.rb
+++ b/recipes/_install.rb
@@ -6,7 +6,6 @@
 
 install_dir = node['zipkin']['install_dir']
 zipkin_user = node['zipkin']['user']
-zipkin_version = node['zipkin']['version']
 
 directory zipkin_version_dir do
   owner zipkin_user
@@ -22,7 +21,7 @@ link install_dir do
 end
 
 remote_file zipkin_jar_path do
-  source "https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=#{zipkin_version}&c=exec"
+  source zipkin_jar_remote_url
   owner zipkin_user
   group zipkin_user
   mode '0755'
@@ -30,7 +29,7 @@ remote_file zipkin_jar_path do
 end
 
 remote_file zipkin_kafka_jar_path do
-  source "https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-autoconfigure-collector-kafka10&v=#{zipkin_version}&c=module"
+  source zipkin_kafka_jar_remote_url
   owner zipkin_user
   group zipkin_user
   mode '0755'


### PR DESCRIPTION
Currently, the remote search URL of Maven central returns a URL to `repo2.maven.org` and this domain has an invalid SSL certificate. This causes the Chef recipe to error out since the underlying Chef resource properly enforces hostname validation on the resulting SSL certificate.

This change removes the search endpoint in favor of directly downloading from the `repo1.maven.org` domain and allowing this to be customized as an attribute.